### PR TITLE
Directed rounding

### DIFF
--- a/LNS/Audit.lean
+++ b/LNS/Audit.lean
@@ -16,6 +16,13 @@ theorem TaylorApprox_Φm (fix : FixedPoint) {x Δ : ℝ}
     (hdn : ∃ n : ℕ, 1 = n * Δ) (hx : x ≤ -1) :
     |Φm x - ΦTm_fix fix Δ x| < Em (-1) Δ + (2 + Δ) * fix.ε := Theorem53_ΦTm' fix hdn hx
 
+theorem TaylorApprox_Φp_dir (fix : FixedPointDir) {x Δ : ℝ} (hd : 0 < Δ) (hx : x ≤ 0) :
+    |Φp x - ΦTp_fix fix Δ x| < Ep 0 Δ + (1 + Δ) * fix.ε := Theorem53_ΦTp_dir fix hd hx
+
+theorem TaylorApprox_Φm_dir (fix : FixedPointDir) {x Δ : ℝ}
+    (hdn : ∃ n : ℕ, 1 = n * Δ) (hx : x ≤ -1) :
+    |Φm x - ΦTm_fix fix Δ x| < Em (-1) Δ + (1 + Δ) * fix.ε := Theorem53_ΦTm_dir' fix hdn hx
+
 theorem TaylorApprox_Φp' (fix : FixedPoint) {x Δ : ℝ} (hd : 0 < Δ) (hx : x ≤ 0) :
     |Φp x - ΦTp_fix fix Δ x| < (Real.log 2 / 8) * Δ ^ 2 + (2 + Δ) * fix.ε := by
   linarith [Theorem53_ΦTp fix hd hx, Ep_bound hd]
@@ -24,6 +31,15 @@ theorem TaylorApprox_Φm' (fix : FixedPoint) {x Δ : ℝ}
     (hdn : ∃ n : ℕ, 1 = n * Δ) (hx : x ≤ -1) :
     |Φm x - ΦTm_fix fix Δ x| < Real.log 2 * Δ ^ 2 + (2 + Δ) * fix.ε := by
   linarith [Theorem53_ΦTm' fix hdn hx, Em_bound (div_one_imp_pos hdn)]
+
+theorem TaylorApprox_Φp_dir' (fix : FixedPointDir) {x Δ : ℝ} (hd : 0 < Δ) (hx : x ≤ 0) :
+    |Φp x - ΦTp_fix fix Δ x| < (Real.log 2 / 8) * Δ ^ 2 + (1 + Δ) * fix.ε := by
+  linarith [Theorem53_ΦTp_dir fix hd hx, Ep_bound hd]
+
+theorem TaylorApprox_Φm_dir' (fix : FixedPointDir) {x Δ : ℝ}
+    (hdn : ∃ n : ℕ, 1 = n * Δ) (hx : x ≤ -1) :
+    |Φm x - ΦTm_fix fix Δ x| < Real.log 2 * Δ ^ 2 + (1 + Δ) * fix.ε := by
+  linarith [Theorem53_ΦTm_dir' fix hdn hx, Em_bound (div_one_imp_pos hdn)]
 
 /- Error correction approximations -/
 
@@ -69,8 +85,12 @@ theorem Cotransformation (fix : FixedPoint)
 
 #print axioms TaylorApprox_Φp
 #print axioms TaylorApprox_Φm
+#print axioms TaylorApprox_Φp_dir
+#print axioms TaylorApprox_Φm_dir
 #print axioms TaylorApprox_Φp'
 #print axioms TaylorApprox_Φm'
+#print axioms TaylorApprox_Φp_dir'
+#print axioms TaylorApprox_Φm_dir'
 #print axioms ErrorCorrection_Φp
 #print axioms ErrorCorrection_Φm
 #print axioms Cotrans_case2

--- a/LNS/Audit.lean
+++ b/LNS/Audit.lean
@@ -81,6 +81,14 @@ theorem Cotransformation (fix : FixedPoint)
     |Φm x - Cotrans fix Φe Δa Δb x| ≤ 5 * fix.ε + 2 * Φe.err :=
   Theorem72 fix Φe ha hb hΔa hΔb
 
+theorem Cotransformation_dir (fix : FixedPointDir)
+    (Φe : FunApprox Φm (Set.Iic (-1)))
+    (ha : 0 < Δa) (hb : 0 < Δb)
+    (hΔa : 2 * fix.ε ≤ Δa)                /- Δa should be large enough -/
+    (hΔb : 4 * fix.ε + 2 * Φe.err ≤ Δb) : /- Δb should be large enough -/
+    |Φm x - Cotrans fix Φe Δa Δb x| ≤ 3 * fix.ε + 2 * Φe.err :=
+  Theorem72_dir fix Φe ha hb hΔa hΔb
+
 /- All theorems depend on standard axioms only: [propext, Classical.choice, Quot.sound]-/
 
 #print axioms TaylorApprox_Φp
@@ -96,3 +104,4 @@ theorem Cotransformation (fix : FixedPoint)
 #print axioms Cotrans_case2
 #print axioms Cotrans_case3
 #print axioms Cotransformation
+#print axioms Cotransformation_dir

--- a/LNS/BasicRounding.lean
+++ b/LNS/BasicRounding.lean
@@ -1,0 +1,35 @@
+import LNS.Definitions
+
+namespace LNS
+
+/- Basic properties of fixed-point rounding -/
+
+lemma FixedPoint.hrnd_sym (fix : FixedPoint) : ∀ x : ℝ, |fix.rnd x - x| ≤ fix.ε := by
+  intro x; rw [abs_sub_comm]; exact fix.hrnd x
+
+lemma FixedPoint.eps_nonneg (fix : FixedPoint) : 0 ≤ fix.ε := le_trans (abs_nonneg _) (fix.hrnd 0)
+
+lemma FixedPointDir.self_sub_rnd (fix : FixedPointDir) :
+    (∀ x, 0 ≤ x - fix.rnd x ∧ x - fix.rnd x ≤ fix.ε) ∨ (∀ x, -fix.ε ≤ x - fix.rnd x ∧ x - fix.rnd x ≤ 0) := by
+  cases fix.rnd_dir with
+  | inl h => left; intro x; specialize h x; split_ands <;> linarith [(abs_le.mp (fix.hrnd x)).2]
+  | inr h => right; intro x; specialize h x; split_ands <;> linarith [(abs_le.mp (fix.hrnd x)).1]
+
+lemma FixedPointDir.abs_rnd_sub_rnd (fix : FixedPointDir) (x y : ℝ) :
+    |(x - fix.rnd x) - (y - fix.rnd y)| ≤ fix.ε := by
+  rw [abs_sub_le_iff]
+  cases fix.self_sub_rnd with
+  | inl h =>
+    have ⟨hx1, hx2⟩ := h x
+    have ⟨hy1, hy2⟩ := h y
+    split_ands <;> linarith
+  | inr h =>
+    have ⟨hx1, hx2⟩ := h x
+    have ⟨hy1, hy2⟩ := h y
+    split_ands <;> linarith
+
+/- Basic properties of function approximations -/
+
+lemma FunApprox.err_sym (g : FunApprox f s) :
+    ∀ x ∈ s, |g x - f x| ≤ g.err := by
+  intro x xs; rw [abs_sub_comm]; exact g.herr x xs

--- a/LNS/Definitions.lean
+++ b/LNS/Definitions.lean
@@ -14,10 +14,12 @@ structure FixedPoint where
   rnd_1 : rnd 1 = 1
   rnd_0 : rnd 0 = 0
 
-lemma FixedPoint.hrnd_sym (fix : FixedPoint) : ∀ x : ℝ, |fix.rnd x - x| ≤ fix.ε := by
-  intro x; rw [abs_sub_comm]; exact fix.hrnd x
+/- Fixed-point arithmetic with directed rounding (down or up) -/
+structure FixedPointDir extends FixedPoint where
+  rnd_dir : (∀ x, rnd x ≤ x) ∨ (∀ x, x ≤ rnd x)
 
-lemma FixedPoint.eps_nonneg (fix : FixedPoint) : 0 ≤ fix.ε := le_trans (abs_nonneg _) (fix.hrnd 0)
+instance : Coe FixedPointDir FixedPoint where
+  coe := FixedPointDir.toFixedPoint
 
 /- FunApprox f s models an approximation of a function f on s -/
 structure FunApprox (f : ℝ → ℝ) (s : Set ℝ) where
@@ -27,10 +29,6 @@ structure FunApprox (f : ℝ → ℝ) (s : Set ℝ) where
 
 instance : CoeFun (FunApprox f s) (fun _ => ℝ → ℝ) where
   coe fapprox := fapprox.fe
-
-lemma FunApprox.err_sym (g : FunApprox f s) :
-    ∀ x ∈ s, |g x - f x| ≤ g.err := by
-  intro x xs; rw [abs_sub_comm]; exact g.herr x xs
 
 open Real
 

--- a/LNS/Theorem53.lean
+++ b/LNS/Theorem53.lean
@@ -1,5 +1,6 @@
 import LNS.Definitions
 import LNS.BasicIxRx
+import LNS.BasicRounding
 import LNS.Lemma51
 import LNS.Lemma52
 
@@ -25,11 +26,35 @@ theorem Theorem53_Ep (fix : FixedPoint) {i r Δ : ℝ} (hi : i ≤ 0) (hr1 : 0 �
     apply mul_le_mul (le_of_lt hr2) i21; simp; linarith
   have i0 : |Ep_fix fix i r| ≤ |Ep i r| + |s1| + |s2| + |s3| := by
     have i01 : |Ep_fix fix i r| ≤ |Ep i r + s1 + s2| + |s3| := by rw [e1]; apply abs_add
-    have i02 : |Ep i r + s1 + s2|  ≤    |Ep i r + s1| + |s2| := by apply abs_add
-    have i03 : |Ep i r + s1|  ≤ |Ep i r| + |s1| := by apply abs_add
+    have i02 : |Ep i r + s1 + s2| ≤ |Ep i r + s1| + |s2| := by apply abs_add
+    have i03 : |Ep i r + s1| ≤ |Ep i r| + |s1| := by apply abs_add
     linarith
   have i01 : |Ep i r| < Ep 0 Δ := by exact Lemma51 hi hr1 hr2
   linarith
+
+theorem Theorem53_Ep_dir (fix : FixedPointDir) {i r Δ : ℝ} (hi : i ≤ 0) (hr1 : 0 ≤ r) (hr2 : r < Δ) :
+    |Ep_fix fix i r| < (Ep 0 Δ) + (1 + Δ) * fix.ε := by
+  set s1 := (Φp i - fix.rnd (Φp i))
+  set s2 := r * (fix.rnd (deriv Φp i) - deriv Φp i)
+  set s3 := r * fix.rnd (deriv Φp i) - fix.rnd (r * fix.rnd (deriv Φp i))
+  have e1 : Ep_fix fix i r = Ep i r + s2 + (s1 - s3) := by unfold Ep_fix Ep; ring_nf
+  have i1 : |s1| ≤ fix.ε := fix.hrnd _
+  have i3 : |s3| ≤ fix.ε := fix.hrnd _
+  have i2 : |s2| ≤ Δ * fix.ε := by
+    have e1 : |s2| = |r| * |(fix.rnd (deriv Φp i) - deriv Φp i)| := by apply abs_mul
+    have e2 : |(fix.rnd (deriv Φp i) - deriv Φp i)| = |(deriv Φp i) - fix.rnd (deriv Φp i)| := by apply abs_sub_comm
+    have e3 : |r| = r := by apply abs_of_nonneg; linarith
+    rw [e1, e2, e3]
+    have i21 : |deriv Φp i - fix.rnd (deriv Φp i)| ≤ fix.ε := by apply fix.hrnd
+    apply mul_le_mul (le_of_lt hr2) i21; simp; linarith
+  have i0 : |Ep_fix fix i r| ≤ |Ep i r| + |s2| + |s1 - s3| := by
+    have i01 : |Ep_fix fix i r| ≤ |Ep i r + s2| + |s1 - s3| := by rw [e1]; apply abs_add
+    have i02 : |Ep i r + s2| ≤ |Ep i r| + |s2| := by apply abs_add
+    linarith
+  have i13 : |s1 - s3| ≤ fix.ε := fix.abs_rnd_sub_rnd _ _
+  have i01 : |Ep i r| < Ep 0 Δ := by exact Lemma51 hi hr1 hr2
+  linarith
+
 
 theorem Theorem53_Em (fix : FixedPoint) {i₀ i r Δ : ℝ} (hi₀ : i₀ < 0) (hi : i ≤ i₀) (hr1 : 0 ≤ r) (hr2 : r < Δ) :
     |Em_fix fix i r| < (Em i₀ Δ) + (2 + Δ) * fix.ε := by

--- a/LNS/Theorem53.lean
+++ b/LNS/Theorem53.lean
@@ -6,82 +6,62 @@ import LNS.Lemma52
 
 namespace LNS
 
+private lemma theorem53_bound (fix : FixedPoint) (hr1 : 0 ≤ r) (hr2 : r ≤ Δ):
+    |x - fix.rnd y + fix.rnd (r * fix.rnd z)| ≤ |x - y + r * z| + Δ * fix.ε + |(y - fix.rnd y) - (r * fix.rnd z - fix.rnd (r * fix.rnd z))| := by
+  set s1 := y - fix.rnd y
+  set s2 := r * (fix.rnd z - z)
+  set s3 := r * fix.rnd  z - fix.rnd (r * fix.rnd z)
+  rw [(by ring : x - fix.rnd y + fix.rnd (r * fix.rnd z) = (x - y + r * z) + s2 + (s1 - s3))]
+  apply le_trans (abs_add _ _)
+  apply add_le_add_right
+  apply le_trans (abs_add _ _)
+  apply add_le_add_left
+  rw [abs_mul, abs_of_nonneg hr1]
+  exact mul_le_mul hr2 (fix.hrnd_sym _) (abs_nonneg _) (by linarith)
+
+private lemma theorem53_bound' (fix : FixedPoint) (hr1 : 0 ≤ r) (hr2 : r ≤ Δ):
+    |x - fix.rnd y + fix.rnd (r * fix.rnd z)| ≤ |x - y + r * z| + (2 + Δ) * fix.ε := by
+  apply le_trans (theorem53_bound fix hr1 hr2)
+  have : |y - fix.rnd y - (r * fix.rnd z - fix.rnd (r * fix.rnd z))| ≤ fix.ε + fix.ε := by
+    apply le_trans (abs_sub _ _)
+    exact add_le_add (fix.hrnd _) (fix.hrnd _)
+  linarith
+
+private lemma theorem53_bound_dir (fix : FixedPointDir) (hr1 : 0 ≤ r) (hr2 : r ≤ Δ):
+    |x - fix.rnd y + fix.rnd (r * fix.rnd z)| ≤ |x - y + r * z| + (1 + Δ) * fix.ε := by
+  apply le_trans (theorem53_bound fix hr1 hr2)
+  have : |y - fix.rnd y - (r * fix.rnd z - fix.rnd (r * fix.rnd z))| ≤ fix.ε := fix.abs_rnd_sub_rnd _ _
+  linarith
+
 theorem Theorem53_Ep (fix : FixedPoint) {i r Δ : ℝ} (hi : i ≤ 0) (hr1 : 0 ≤ r) (hr2 : r < Δ) :
     |Ep_fix fix i r| < (Ep 0 Δ) + (2 + Δ) * fix.ε := by
-  set s1 := (Φp i - fix.rnd (Φp i))
-  set s2 := r * (fix.rnd (deriv Φp i) - deriv Φp i)
-  set s3 := (fix.rnd (r * fix.rnd (deriv Φp i)) - r * fix.rnd (deriv Φp i))
-  have e1 : Ep_fix fix i r = Ep i r + s1 + s2 + s3 := by unfold Ep_fix Ep; ring_nf
-  have i1 : |s1| ≤ fix.ε := by apply fix.hrnd
-  have i3 : |s3| ≤ fix.ε := by
-    have : |s3| = |r * fix.rnd (deriv Φp i) - fix.rnd (r * fix.rnd (deriv Φp i))| := by apply abs_sub_comm
-    rw [this]
-    apply fix.hrnd
-  have i2 : |s2| ≤ Δ * fix.ε := by
-    have e1 : |s2| = |r| * |(fix.rnd (deriv Φp i) - deriv Φp i)| := by apply abs_mul
-    have e2 : |(fix.rnd (deriv Φp i) - deriv Φp i)| = |(deriv Φp i) - fix.rnd (deriv Φp i)| := by apply abs_sub_comm
-    have e3 : |r| = r := by apply abs_of_nonneg; linarith
-    rw [e1, e2, e3]
-    have i21 : |deriv Φp i - fix.rnd (deriv Φp i)| ≤ fix.ε := by apply fix.hrnd
-    apply mul_le_mul (le_of_lt hr2) i21; simp; linarith
-  have i0 : |Ep_fix fix i r| ≤ |Ep i r| + |s1| + |s2| + |s3| := by
-    have i01 : |Ep_fix fix i r| ≤ |Ep i r + s1 + s2| + |s3| := by rw [e1]; apply abs_add
-    have i02 : |Ep i r + s1 + s2| ≤ |Ep i r + s1| + |s2| := by apply abs_add
-    have i03 : |Ep i r + s1| ≤ |Ep i r| + |s1| := by apply abs_add
-    linarith
-  have i01 : |Ep i r| < Ep 0 Δ := by exact Lemma51 hi hr1 hr2
-  linarith
+  apply lt_of_le_of_lt (theorem53_bound' fix hr1 (le_of_lt hr2))
+  apply add_lt_add_right
+  exact Lemma51 hi hr1 hr2
 
 theorem Theorem53_Ep_dir (fix : FixedPointDir) {i r Δ : ℝ} (hi : i ≤ 0) (hr1 : 0 ≤ r) (hr2 : r < Δ) :
     |Ep_fix fix i r| < (Ep 0 Δ) + (1 + Δ) * fix.ε := by
-  set s1 := (Φp i - fix.rnd (Φp i))
-  set s2 := r * (fix.rnd (deriv Φp i) - deriv Φp i)
-  set s3 := r * fix.rnd (deriv Φp i) - fix.rnd (r * fix.rnd (deriv Φp i))
-  have e1 : Ep_fix fix i r = Ep i r + s2 + (s1 - s3) := by unfold Ep_fix Ep; ring_nf
-  have i1 : |s1| ≤ fix.ε := fix.hrnd _
-  have i3 : |s3| ≤ fix.ε := fix.hrnd _
-  have i2 : |s2| ≤ Δ * fix.ε := by
-    have e1 : |s2| = |r| * |(fix.rnd (deriv Φp i) - deriv Φp i)| := by apply abs_mul
-    have e2 : |(fix.rnd (deriv Φp i) - deriv Φp i)| = |(deriv Φp i) - fix.rnd (deriv Φp i)| := by apply abs_sub_comm
-    have e3 : |r| = r := by apply abs_of_nonneg; linarith
-    rw [e1, e2, e3]
-    have i21 : |deriv Φp i - fix.rnd (deriv Φp i)| ≤ fix.ε := by apply fix.hrnd
-    apply mul_le_mul (le_of_lt hr2) i21; simp; linarith
-  have i0 : |Ep_fix fix i r| ≤ |Ep i r| + |s2| + |s1 - s3| := by
-    have i01 : |Ep_fix fix i r| ≤ |Ep i r + s2| + |s1 - s3| := by rw [e1]; apply abs_add
-    have i02 : |Ep i r + s2| ≤ |Ep i r| + |s2| := by apply abs_add
-    linarith
-  have i13 : |s1 - s3| ≤ fix.ε := fix.abs_rnd_sub_rnd _ _
-  have i01 : |Ep i r| < Ep 0 Δ := by exact Lemma51 hi hr1 hr2
-  linarith
-
+  apply lt_of_le_of_lt (theorem53_bound_dir fix hr1 (le_of_lt hr2))
+  apply add_lt_add_right
+  exact Lemma51 hi hr1 hr2
 
 theorem Theorem53_Em (fix : FixedPoint) {i₀ i r Δ : ℝ} (hi₀ : i₀ < 0) (hi : i ≤ i₀) (hr1 : 0 ≤ r) (hr2 : r < Δ) :
     |Em_fix fix i r| < (Em i₀ Δ) + (2 + Δ) * fix.ε := by
-  set s1 := (Φm i - fix.rnd (Φm i))
-  set s2 := r*(fix.rnd (deriv Φm i) - deriv Φm i)
-  set s3 := (fix.rnd (r * fix.rnd (deriv Φm i)) - r * fix.rnd (deriv Φm i))
-  have e1 : Em_fix fix i r = (-Em i r) + s1 + s2 + s3 := by unfold Em_fix Em; ring_nf
-  have i1 : |s1| ≤ fix.ε := by apply fix.hrnd
-  have i3 : |s3| ≤ fix.ε := by
-    have : |s3| = |r * fix.rnd (deriv Φm i) - fix.rnd (r * fix.rnd (deriv Φm i))| := by apply abs_sub_comm
-    rw [this]
-    apply fix.hrnd
-  have i2 : |s2| ≤ Δ*fix.ε := by
-    have e1 : |s2| = |r| * |(fix.rnd (deriv Φm i) - deriv Φm i)| := by apply abs_mul
-    have e2 : |(fix.rnd (deriv Φm i) - deriv Φm i)| = |(deriv Φm i) - fix.rnd (deriv Φm i)| := by apply abs_sub_comm
-    have e3 : |r| = r := by apply abs_of_nonneg; linarith
-    rw [e1, e2, e3]
-    have i21 : |deriv Φm i - fix.rnd (deriv Φm i)| ≤ fix.ε := by apply fix.hrnd
-    apply mul_le_mul (le_of_lt hr2) i21; simp; linarith
-  have i0 : |Em_fix fix i r| ≤ |Em i r| + |s1| + |s2| + |s3| := by
-    have i01 : |Em_fix fix i r| ≤ |-Em i r + s1 + s2| + |s3| := by rw [e1]; apply abs_add
-    have i02 : |-Em i r + s1 + s2| ≤ |-Em i r + s1| + |s2| := by apply abs_add
-    have i03 : |-Em i r + s1| ≤ |-Em i r| + |s1| := by apply abs_add
-    have i04 : |-Em i r| =|Em i r| := by apply abs_neg
-    linarith
-  have i01 : |Em i r| < Em i₀ Δ := by exact Lemma52 hi₀ hi hr1 hr2
-  linarith
+  apply lt_of_le_of_lt (theorem53_bound' fix hr1 (le_of_lt hr2))
+  apply add_lt_add_right
+  have : |Φm (i - r) - Φm i + r * deriv Φm i| = |Em i r| := by
+    unfold Em; rw [← abs_neg]; congr; ring
+  rw [this]
+  exact Lemma52 hi₀ hi hr1 hr2
+
+theorem Theorem53_Em_dir (fix : FixedPointDir) {i₀ i r Δ : ℝ} (hi₀ : i₀ < 0) (hi : i ≤ i₀) (hr1 : 0 ≤ r) (hr2 : r < Δ) :
+    |Em_fix fix i r| < (Em i₀ Δ) + (1 + Δ) * fix.ε := by
+  apply lt_of_le_of_lt (theorem53_bound_dir fix hr1 (le_of_lt hr2))
+  apply add_lt_add_right
+  have : |Φm (i - r) - Φm i + r * deriv Φm i| = |Em i r| := by
+    unfold Em; rw [← abs_neg]; congr; ring
+  rw [this]
+  exact Lemma52 hi₀ hi hr1 hr2
 
 /- A first order Taylor approximation error bound for Φ⁺ -/
 
@@ -93,6 +73,14 @@ theorem Theorem53_ΦTp (fix : FixedPoint) {x Δ : ℝ} (hd : 0 < Δ) (hx : x ≤
   apply Theorem53_Ep fix _ (rx_nonneg hd x) (rx_lt_delta hd x)
   rw [← x_neg_iff_ix_neg hd]; exact hx
 
+theorem Theorem53_ΦTp_dir (fix : FixedPointDir) {x Δ : ℝ} (hd : 0 < Δ) (hx : x ≤ 0) :
+    |Φp x - ΦTp_fix fix Δ x| < Ep 0 Δ + (1 + Δ) * fix.ε := by
+  have eq : Φp x - ΦTp_fix fix Δ x = Ep_fix fix (Iₓ Δ x) (Rₓ Δ x) := by
+    unfold ΦTp_fix Ep_fix; rw [i_sub_r_eq_x]; ring_nf
+  rw [eq]
+  apply Theorem53_Ep_dir fix _ (rx_nonneg hd x) (rx_lt_delta hd x)
+  rw [← x_neg_iff_ix_neg hd]; exact hx
+
 /- A first order Taylor approximation error bound for Φ⁻ -/
 
 theorem Theorem53_ΦTm (fix : FixedPoint) {x₀ x Δ : ℝ} (hd : 0 < Δ) (hx₀ : x₀ ≤ -Δ) (hx : x ≤ x₀) :
@@ -101,6 +89,13 @@ theorem Theorem53_ΦTm (fix : FixedPoint) {x₀ x Δ : ℝ} (hd : 0 < Δ) (hx₀
     unfold ΦTm_fix Em_fix; rw [i_sub_r_eq_x]; ring_nf
   rw [eq]
   exact Theorem53_Em fix (ix_lt_zero hd hx₀) (ix_monotone hd hx) (rx_nonneg hd x) (rx_lt_delta hd x)
+
+theorem Theorem53_ΦTm_dir (fix : FixedPointDir) {x₀ x Δ : ℝ} (hd : 0 < Δ) (hx₀ : x₀ ≤ -Δ) (hx : x ≤ x₀) :
+    |Φm x - ΦTm_fix fix Δ x| < Em (Iₓ Δ x₀) Δ + (1 + Δ) * fix.ε := by
+  have eq : Φm x - ΦTm_fix fix Δ x = Em_fix fix (Iₓ Δ x) (Rₓ Δ x) := by
+    unfold ΦTm_fix Em_fix; rw [i_sub_r_eq_x]; ring_nf
+  rw [eq]
+  exact Theorem53_Em_dir fix (ix_lt_zero hd hx₀) (ix_monotone hd hx) (rx_nonneg hd x) (rx_lt_delta hd x)
 
 /- A first order Taylor approximation of Φ⁻ for x ≤ -1 -/
 
@@ -111,6 +106,13 @@ theorem Theorem53_ΦTm' (fix : FixedPoint) {x Δ : ℝ}
   rw [← ix_eq_neg_one hdn]
   exact Theorem53_ΦTm fix (div_one_imp_pos hdn) hx₀ hx
 
+theorem Theorem53_ΦTm_dir' (fix : FixedPointDir) {x Δ : ℝ}
+    (hdn : ∃ n : ℕ, 1 = n * Δ) (hx : x ≤ -1) :
+    |Φm x - ΦTm_fix fix Δ x| < Em (-1) Δ + (1 + Δ) * fix.ε := by
+  have hx₀ : -1 ≤ -Δ := by rw [neg_le_neg_iff]; exact div_one_imp_le_one hdn
+  rw [← ix_eq_neg_one hdn]
+  exact Theorem53_ΦTm_dir fix (div_one_imp_pos hdn) hx₀ hx
+
 /- Taylor approximations of Φ⁺ and Φ⁻ -/
 
 noncomputable def ΦTp_approx (fix : FixedPoint) {Δ : ℝ} (hd : 0 < Δ) : FunApprox Φp (Set.Iic 0) := {
@@ -119,8 +121,20 @@ noncomputable def ΦTp_approx (fix : FixedPoint) {Δ : ℝ} (hd : 0 < Δ) : FunA
   herr := fun _ => le_of_lt ∘ Theorem53_ΦTp fix hd
 }
 
+noncomputable def ΦTp_dir_approx (fix : FixedPointDir) {Δ : ℝ} (hd : 0 < Δ) : FunApprox Φp (Set.Iic 0) := {
+  fe := ΦTp_fix fix Δ
+  err := Ep 0 Δ + (1 + Δ) * fix.ε
+  herr := fun _ => le_of_lt ∘ Theorem53_ΦTp_dir fix hd
+}
+
 noncomputable def ΦTm_approx (fix : FixedPoint) {Δ : ℝ} (hdn : ∃ n : ℕ, 1 = n * Δ) : FunApprox Φm (Set.Iic (-1)) := {
   fe := ΦTm_fix fix Δ
   err := Em (-1) Δ + (2 + Δ) * fix.ε
   herr := fun _ => le_of_lt ∘ Theorem53_ΦTm' fix hdn
+}
+
+noncomputable def ΦTm_dir_approx (fix : FixedPointDir) {Δ : ℝ} (hdn : ∃ n : ℕ, 1 = n * Δ) : FunApprox Φm (Set.Iic (-1)) := {
+  fe := ΦTm_fix fix Δ
+  err := Em (-1) Δ + (1 + Δ) * fix.ε
+  herr := fun _ => le_of_lt ∘ Theorem53_ΦTm_dir' fix hdn
 }

--- a/LNS/Theorem68.lean
+++ b/LNS/Theorem68.lean
@@ -1,5 +1,6 @@
 import LNS.Definitions
 import LNS.BasicIxRx
+import LNS.BasicRounding
 import LNS.Lemma63
 import LNS.Lemma64
 import LNS.Lemma67

--- a/LNS/Theorem72.lean
+++ b/LNS/Theorem72.lean
@@ -238,18 +238,16 @@ end Cotrans2
 
 section Contrans3
 
-variable (fix : FixedPoint)
-
 lemma k2_alt (ha : 0 < Δa) (hb : 0 < Δb) : k₂ Δb x = x + Φm (rb Δa Δb x) + Φm (k₁ Δa Δb x) - Φm (ind Δb x) := by
   have e2 : Φm (rem Δb x) = Φm (rb Δa Δb x) + Φm (k₁ Δa Δb x) := by
     rw [cotransformation ha (rem_lt_zero hb), rb, k₁, kval]
   unfold k₂ kval
   rw [e2]; ring
 
-lemma cotrans3 (hb : 0 < Δb) (hx : x < 0) : Φm x = Φm (ind Δb x) +  Φm (k₂ Δb x) :=
+lemma cotrans3 (hb : 0 < Δb) (hx : x < 0) : Φm x = Φm (ind Δb x) + Φm (k₂ Δb x) :=
   by rw [cotransformation hb hx, k₂]
 
-lemma k2rnd_fix_bound (hc : c < 0) (Φe : FunApprox Φm (Set.Iic c))
+lemma k2rnd_fix_bound (fix : FixedPoint) (hc : c < 0) (Φe : FunApprox Φm (Set.Iic c))
     (ha : 0 < Δa) (hb : 0 < Δb)
     (hk1 : k₁ Δa Δb x ≤ c) (hk1r : k1rnd fix Δa Δb x ≤ c) :
     |k₂ Δb x - k2rnd fix Φe Δa Δb x| ≤ 2 * fix.ε +  Φm (c - 2 * fix.ε) - Φm c + Φe.err := by
@@ -271,13 +269,31 @@ lemma k2rnd_fix_bound (hc : c < 0) (Φe : FunApprox Φm (Set.Iic c))
     apply krnd_fix_bound
   linarith
 
-lemma bound_case3 (hc : c < 0) (Φe : FunApprox Φm (Set.Iic c))
-    (ha : 0 < Δa) (hb : 0 < Δb) (hx : x < 0)
-    (hk1 : k₁ Δa Δb x ≤ c) (hk1r : k1rnd fix Δa Δb x ≤ c)
-    (hk2 : k₂ Δb x ≤ c) (hk2r : k2rnd fix Φe Δa Δb x ≤ c) :
-    let Ek2 := 2 * fix.ε +  Φm (c - 2 * fix.ε) - Φm c + Φe.err
+lemma k2rnd_fix_bound_dir (fix : FixedPointDir) (hc : c < 0) (Φe : FunApprox Φm (Set.Iic c))
+    (ha : 0 < Δa) (hb : 0 < Δb)
+    (hk1 : k₁ Δa Δb x ≤ c) (hk1r : k1rnd fix Δa Δb x ≤ c) :
+    |k₂ Δb x - k2rnd fix Φe Δa Δb x| ≤ fix.ε +  Φm (c - fix.ε) - Φm c + Φe.err := by
+  set a1 := Φm (rb Δa Δb x) - fix.rnd (Φm (rb Δa Δb x))
+  set a2 := Φm (ind Δb x) - fix.rnd (Φm (ind Δb x))
+  set a3 := Φm (k₁ Δa Δb x) - Φm (k1rnd fix Δa Δb x)
+  set a4 := Φm (k1rnd fix Δa Δb x) - Φe (k1rnd fix Δa Δb x)
+  have e : k₂ Δb x - k2rnd fix Φe Δa Δb x = (a1 - a2) + a3 + a4 := by
+    unfold k2rnd; rw [k2_alt ha hb]; ring
+  rw [e]
+  have i00 : |(a1 - a2) + a3 + a4| ≤ |(a1 - a2) + a3| + |a4| := by apply abs_add
+  have i01 : |(a1 - a2) + a3| ≤ |a1 - a2| + |a3| := by apply abs_add
+  have i12 : |a1 - a2| ≤ fix.ε := fix.abs_rnd_sub_rnd _ _
+  have i4 : |a4| ≤ Φe.err := by apply Φe.herr; apply hk1r
+  have i3 : |a3| ≤  Φm (c - fix.ε) - Φm c := by
+    apply Lemma71 hc hk1 hk1r
+    apply krnd_fix_bound_dir
+  linarith
+
+lemma bound_case3 (fix : FixedPoint) (hc : c < 0) (Φe : FunApprox Φm (Set.Iic c))
+    (hb : 0 < Δb) (hx : x < 0)
+    (hk2 : k₂ Δb x ≤ c) (hk2r : k2rnd fix Φe Δa Δb x ≤ c)
+    (hk2rnd : |k₂ Δb x - k2rnd fix Φe Δa Δb x| ≤ Ek2) :
     |Φm x - Cotrans₃ fix Φe Δa Δb x| ≤ fix.ε + Φm (c - Ek2) - Φm c + Φe.err := by
-  intro Ek2
   rw [cotrans3 hb hx]
   set s1 := Φm (ind Δb x) - fix.rnd (Φm (ind Δb x))
   set s2 := Φm (k₂ Δb x) - Φm (k2rnd fix Φe Δa Δb x)
@@ -289,16 +305,14 @@ lemma bound_case3 (hc : c < 0) (Φe : FunApprox Φm (Set.Iic c))
   have i02 : |s1 + s2| ≤ |s1| + |s2| := by apply abs_add
   have i1 : |s1| ≤ fix.ε := by apply fix.hrnd
   have i3 : |s3| ≤ Φe.err := by apply Φe.herr; apply hk2r
-  have i2 : |s2| ≤ Φm (c - Ek2) - Φm c := by
-    apply Lemma71 hc hk2 hk2r
-    exact k2rnd_fix_bound fix hc Φe ha hb hk1 hk1r
+  have i2 : |s2| ≤ Φm (c - Ek2) - Φm c := by apply Lemma71 hc hk2 hk2r hk2rnd
   linarith
 
 /- Note: If rem Δb x ∈ (-Δa, 0) then use Contrans₂ fix Δb x
    since Φm (rem Δb x) can be computed directly from
    a table defined for all values in (-Δa, 0) -/
 
-theorem Theorem72_case3
+theorem Theorem72_case3 (fix : FixedPoint)
     (Φe : FunApprox Φm (Set.Iic (-1)))  /- An approximation of Φm on (-∞, -1] -/
     (ha : 0 < Δa) (hb : 0 < Δb) (hrem : rem Δb x ≤ -Δa)
     (hΔa : 4 * fix.ε ≤ Δa)              /- Δa should be large enough -/
@@ -309,15 +323,35 @@ theorem Theorem72_case3
   have hk1 : k₁ Δa Δb x ≤ -1 := by apply k_bound'' ha hrem
   have hk1r : k1rnd fix Δa Δb x ≤ -1 := by unfold k1rnd; linarith [krnd_bound fix ha hrem]
   have hk2 : k₂ Δb x ≤ -1 := by unfold k₂; exact k_bound'' hb hx
-  apply bound_case3 fix neg_one_lt_zero Φe ha (by linarith) (by linarith) hk1 hk1r hk2
+  have hk2rnd := k2rnd_fix_bound fix neg_one_lt_zero Φe ha hb hk1 hk1r
+  apply bound_case3 fix neg_one_lt_zero Φe hb (by linarith) hk2 _ hk2rnd
   have ineq1 := (abs_le.mp $ k2rnd_fix_bound fix neg_one_lt_zero Φe ha hb hk1 hk1r).1
   have ineq2 := k_bound' hb hx
   have ineq3 := phi_sub_phi_bound' (by linarith [fix.eps_nonneg] : 0 ≤ 2 * fix.ε)
   unfold k₂ at ineq1
   linarith
 
+theorem Theorem72_case3_dir (fix : FixedPointDir)
+    (Φe : FunApprox Φm (Set.Iic (-1)))  /- An approximation of Φm on (-∞, -1] -/
+    (ha : 0 < Δa) (hb : 0 < Δb) (hrem : rem Δb x ≤ -Δa)
+    (hΔa : 2 * fix.ε ≤ Δa)              /- Δa should be large enough -/
+    (hΔb : 4 * fix.ε + 2 * Φe.err ≤ Δb) /- Δb should be large enough -/
+    (hx : x ≤ -Δb) :                    /- The result is valid for all x ∈ (-∞, -Δb] -/
+    let Ek2 := fix.ε + Φm (-1 - fix.ε) - Φm (-1) + Φe.err
+    |Φm x - Cotrans₃ fix Φe Δa Δb x| ≤ fix.ε + Φm (-1 - Ek2) - Φm (-1) + Φe.err := by
+  have hk1 : k₁ Δa Δb x ≤ -1 := by apply k_bound'' ha hrem
+  have hk1r : k1rnd fix Δa Δb x ≤ -1 := by unfold k1rnd; linarith [krnd_bound_dir fix ha hrem]
+  have hk2 : k₂ Δb x ≤ -1 := by unfold k₂; exact k_bound'' hb hx
+  have hk2rnd := k2rnd_fix_bound_dir fix neg_one_lt_zero Φe ha hb hk1 hk1r
+  apply bound_case3 fix neg_one_lt_zero Φe hb (by linarith) hk2 _ hk2rnd
+  have ineq1 := (abs_le.mp $ k2rnd_fix_bound_dir fix neg_one_lt_zero Φe ha hb hk1 hk1r).1
+  have ineq2 := k_bound' hb hx
+  have ineq3 := phi_sub_phi_bound' fix.eps_nonneg
+  unfold k₂ at ineq1
+  linarith
+
 /- A simplified error bound -/
-theorem Theorem72_case3'
+theorem Theorem72_case3' (fix : FixedPoint)
     (Φe : FunApprox Φm (Set.Iic (-1)))  /- An approximation of Φm on (-∞, -1] -/
     (ha : 0 < Δa) (hb : 0 < Δb) (hrem : rem Δb x ≤ -Δa)
     (hΔa : 4 * fix.ε ≤ Δa)              /- Δa should be large enough -/
@@ -334,15 +368,30 @@ theorem Theorem72_case3'
   have ineq3 := phi_sub_phi_bound' (by linarith [fix.eps_nonneg] : 0 ≤ 2 * fix.ε)
   linarith
 
+theorem Theorem72_case3_dir' (fix : FixedPointDir)
+    (Φe : FunApprox Φm (Set.Iic (-1)))  /- An approximation of Φm on (-∞, -1] -/
+    (ha : 0 < Δa) (hb : 0 < Δb) (hrem : rem Δb x ≤ -Δa)
+    (hΔa : 2 * fix.ε ≤ Δa)              /- Δa should be large enough -/
+    (hΔb : 4 * fix.ε + 2 * Φe.err ≤ Δb) /- Δb should be large enough -/
+    (hx : x ≤ -Δb) :                    /- The result is valid for all x ∈ (-∞, -Δb] -/
+    |Φm x - Cotrans₃ fix Φe Δa Δb x| ≤ 3 * fix.ε + 2 * Φe.err := by
+  have hk1 : k₁ Δa Δb x ≤ -1 := by apply k_bound'' ha hrem
+  have hk1r : k1rnd fix Δa Δb x ≤ -1 := by unfold k1rnd; linarith [krnd_bound_dir fix ha hrem]
+  apply le_trans (Theorem72_case3_dir fix Φe ha hb hrem hΔa hΔb hx)
+  have ineq1 : 0 ≤ fix.ε + Φm (-1 - fix.ε) - Φm (-1) + Φe.err := by
+    apply (le_trans (abs_nonneg $ k₂ Δb x - k2rnd fix Φe Δa Δb x))
+    exact k2rnd_fix_bound_dir fix neg_one_lt_zero Φe ha hb hk1 hk1r
+  have ineq2 := phi_sub_phi_bound' ineq1
+  have ineq3 := phi_sub_phi_bound' fix.eps_nonneg
+  linarith
+
 end Contrans3
 
 /- A general result -/
 
 section Cotrans
 
-variable (fix : FixedPoint)
-
-theorem Theorem72
+theorem Theorem72 (fix : FixedPoint)
     (Φe : FunApprox Φm (Set.Iic (-1)))
     (ha : 0 < Δa) (hb : 0 < Δb)
     (hΔa : 4 * fix.ε ≤ Δa)                /- Δa should be large enough -/
@@ -360,5 +409,24 @@ theorem Theorem72
     have := Theorem72_case2' fix Φe hb ineq (by linarith : x ≤ -Δb)
     linarith
   · apply Theorem72_case3' fix Φe ha hb (by linarith) hΔa hΔb (by linarith)
+
+theorem Theorem72_dir (fix : FixedPointDir)
+    (Φe : FunApprox Φm (Set.Iic (-1)))
+    (ha : 0 < Δa) (hb : 0 < Δb)
+    (hΔa : 2 * fix.ε ≤ Δa)                /- Δa should be large enough -/
+    (hΔb : 4 * fix.ε + 2 * Φe.err ≤ Δb) : /- Δb should be large enough -/
+    |Φm x - Cotrans fix Φe Δa Δb x| ≤ 3 * fix.ε + 2 * Φe.err := by
+  have hε := fix.eps_nonneg
+  have herr : 0 ≤ Φe.err := by
+    apply le_trans (abs_nonneg _) (Φe.herr (-1) _)
+    simp only [Set.mem_Iic, le_refl]
+  unfold Cotrans
+  split_ifs with hax hbx hrem
+  · linarith [fix.hrnd (Φm x)]
+  · linarith [Theorem72_case2_dir' fix Φe ha hΔa (by linarith : x ≤ -Δa)]
+  · have ineq : 2 * fix.ε ≤ Δb := by linarith
+    have := Theorem72_case2_dir' fix Φe hb ineq (by linarith : x ≤ -Δb)
+    linarith
+  · apply Theorem72_case3_dir' fix Φe ha hb (by linarith) hΔa hΔb (by linarith)
 
 end Cotrans

--- a/LNS/Theorem72.lean
+++ b/LNS/Theorem72.lean
@@ -1,5 +1,6 @@
 import LNS.Definitions
 import LNS.BasicIxRx
+import LNS.BasicRounding
 import LNS.Lemma71
 
 namespace LNS

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ All proof files are located in the [LNS](LNS) directory.
 
 [`Tactic.lean`](LNS/Tactic.lean) A tactic for computing derivatives.  
 [`Common.lean`](LNS/Common.lean) Some general lemmas.  
+[`BasicRounding.lean`](LNS/BasicRounding.lean) Basic properties of fixed-point rounding and approximations of functions.  
 [`BasicIxRx.lean`](LNS/BasicIxRx.lean) Basic properties of index functions `Iₓ`, `Rₓ`, `ind` and `rem`.  
 [`BasicPhi.lean`](LNS/BasicPhi.lean) Basic properties of `Φ⁺` and `Φ⁻`.  
 


### PR DESCRIPTION
- Added a definition for directed fixed-point rounding:
```lean
structure FixedPointDir extends FixedPoint where
  rnd_dir : (∀ x, rnd x ≤ x) ∨ (∀ x, x ≤ rnd x)
```
- Proved Taylor approximation bounds for directed rounding: `Ep 0 Δ + (1 + Δ) * fix.ε` and `Em (-1) Δ + (1 + Δ) * fix.ε`.
- Proved co-transformation bounds for directed rounding.
